### PR TITLE
Add manual fixes for incorrect controller types in RIO 1.09.00

### DIFF
--- a/aiorussound/const.py
+++ b/aiorussound/const.py
@@ -160,3 +160,8 @@ VERSIONS_BY_FLAGS = defaultdict(list)
 for version, flags in FLAGS_BY_VERSION.items():
     for flag in flags:
         VERSIONS_BY_FLAGS[flag] = version
+
+CONTROLLER_TYPE_FIX_MAP = {
+    "MCA-C6": "MCA-C5",
+    "XStream-X5": "XSource",
+}

--- a/aiorussound/rio.py
+++ b/aiorussound/rio.py
@@ -17,7 +17,7 @@ from aiorussound.const import (
     MAX_RNET_CONTROLLERS,
     RESPONSE_REGEX,
     KEEP_ALIVE_INTERVAL,
-    TIMEOUT,
+    TIMEOUT, CONTROLLER_TYPE_FIX_MAP,
 )
 from aiorussound.exceptions import (
     CommandError,
@@ -377,6 +377,8 @@ class RussoundClient:
             controller_type = await self.get_variable(device_str, "type")
             if not controller_type:
                 return None
+            if controller_type in CONTROLLER_TYPE_FIX_MAP:
+                controller_type = CONTROLLER_TYPE_FIX_MAP[controller_type]
             mac_address = None
             try:
                 mac_address = await self.get_variable(device_str, "macAddress")


### PR DESCRIPTION
## Overview

In RIO ver. 1.09.00, the MCA-C3/C5 is accidentally reported as a `MCA-C6`, and the XStream series (most likely XSource) is reported as an `XStream-X5`. A map was added to correct these controller types.